### PR TITLE
Flirtlib interface

### DIFF
--- a/include/flirtlib_ros/flirtlib.h
+++ b/include/flirtlib_ros/flirtlib.h
@@ -83,6 +83,7 @@ public:
   InterestPointVec extractFeatures(const std::vector<sensor_msgs::LaserScan>& scans, const std::vector<tf::StampedTransform>& transforms) const;
 
   /// Returns the ransac matcher, should be replaced by a generic matching interface
+  /// that supports different matching
   boost::shared_ptr<RansacFeatureSetMatcher> matcher()
   {
     return ransac_;
@@ -110,7 +111,6 @@ public:
   boost::shared_ptr<Detector> detector_;
   boost::shared_ptr<DescriptorGenerator> descriptor_;
   boost::shared_ptr<RansacFeatureSetMatcher> ransac_;
-  
 };
 
 } // namespace

--- a/include/flirtlib_ros/flirtlib.h
+++ b/include/flirtlib_ros/flirtlib.h
@@ -57,6 +57,7 @@
 #include <flirtlib/utils/SimpleMinMaxPeakFinder.h>
 #include <flirtlib/utils/HistogramDistances.h>
 #include <sensor_msgs/LaserScan.h>
+#include <tf/tf.h>
 #include <ros/ros.h>
 
 namespace flirtlib_ros
@@ -64,20 +65,52 @@ namespace flirtlib_ros
 
 typedef std::vector<InterestPoint*> InterestPointVec;
 
-struct FlirtlibFeatures
+class FlirtlibFeatures
 {
+public:
   /// Initialize Flirtlib objects based on ros parameters.  Specifying the
   /// node handle argument allows selecting the ros namespace in which the
   /// parameters will be searched for.
   FlirtlibFeatures (ros::NodeHandle nh = ros::NodeHandle("~"));
-  
+
+  /// Extracts the features and their descriptors
+  InterestPointVec extractFeatures (sensor_msgs::LaserScan::ConstPtr scan) const;
+
+  /// Extracts points from a scan and transforms them to a different frame
+  InterestPointVec extractFeatures (const sensor_msgs::LaserScan& scan, const tf::StampedTransform& transform) const;
+
+  /// Extracts the features from multiple scans
+  InterestPointVec extractFeatures(const std::vector<sensor_msgs::LaserScan>& scans, const std::vector<tf::StampedTransform>& transforms) const;
+
+  /// Returns the ransac matcher, should be replaced by a generic matching interface
+  boost::shared_ptr<RansacFeatureSetMatcher> matcher()
+  {
+    return ransac_;
+  }
+
+ private:
+
+  ros::NodeHandle nh_;
+
+  std::string detector_type_;
+  std::string descriptor_type_;
+  std::string matcher_type_;
+  double detector_scale_;
+  double detector_minimum_spanning_trees_num_;
+  double detector_base_sigma_;
+  double detector_sigma_step_;
+  int detector_window_;
+  double descriptor_min_rho_;
+  double descriptor_max_rho_;
+  double descriptor_bin_rho_;
+  double descriptor_bin_phi_;
+
   boost::shared_ptr<SimpleMinMaxPeakFinder> peak_finder_;
   boost::shared_ptr<HistogramDistance<double> > histogram_dist_;
   boost::shared_ptr<Detector> detector_;
   boost::shared_ptr<DescriptorGenerator> descriptor_;
   boost::shared_ptr<RansacFeatureSetMatcher> ransac_;
   
-  InterestPointVec extractFeatures (sensor_msgs::LaserScan::ConstPtr scan) const;
 };
 
 } // namespace

--- a/include/flirtlib_ros/flirtlib.h
+++ b/include/flirtlib_ros/flirtlib.h
@@ -76,10 +76,10 @@ public:
   /// Extracts the features and their descriptors
   InterestPointVec extractFeatures (sensor_msgs::LaserScan::ConstPtr scan) const;
 
-  /// Extracts points from a scan and transforms them to a different frame
+  /// Extracts the features and their descriptors and transforms them to a different frame
   InterestPointVec extractFeatures (const sensor_msgs::LaserScan& scan, const tf::StampedTransform& transform) const;
 
-  /// Extracts the features from multiple scans
+  /// Extracts the features and their descriptors multiple scans and transforms them to a different frame
   InterestPointVec extractFeatures(const std::vector<sensor_msgs::LaserScan>& scans, const std::vector<tf::StampedTransform>& transforms) const;
 
   /// Returns the ransac matcher, should be replaced by a generic matching interface

--- a/src/flirtlib.cpp
+++ b/src/flirtlib.cpp
@@ -44,11 +44,6 @@
 namespace flirtlib_ros
 {
 
-using std::string;
-namespace sm=sensor_msgs;
-
-
-
 FlirtlibFeatures::FlirtlibFeatures (ros::NodeHandle nh)
   : nh_(nh)
   , detector_type_("curvature")
@@ -79,9 +74,6 @@ FlirtlibFeatures::FlirtlibFeatures (ros::NodeHandle nh)
 
   peak_finder_.reset(new SimpleMinMaxPeakFinder(0.34, 0.001));
   histogram_dist_.reset(new SymmetricChi2Distance<double>());
-
-  peak_finder_ = boost::shared_ptr<SimpleMinMaxPeakFinder>(new SimpleMinMaxPeakFinder(0.34, 0.001));
-  histogram_dist_ = boost::shared_ptr<HistogramDistance<double> >(new SymmetricChi2Distance<double>());
 
   // Detector
   if (detector_type_ == "curvature")
@@ -126,9 +118,8 @@ FlirtlibFeatures::FlirtlibFeatures (ros::NodeHandle nh)
   ransac_.reset(new RansacFeatureSetMatcher(0.0299, 0.95, 0.2, 0.1,0.0184, false));
 }
 
-// Extract flirtlib features
 InterestPointVec
-FlirtlibFeatures::extractFeatures (sm::LaserScan::ConstPtr scan) const
+FlirtlibFeatures::extractFeatures (sensor_msgs::LaserScan::ConstPtr scan) const
 {
   boost::shared_ptr<LaserReading> reading = fromRos(*scan);
   InterestPointVec pts;
@@ -138,9 +129,8 @@ FlirtlibFeatures::extractFeatures (sm::LaserScan::ConstPtr scan) const
   return pts;
 }
 
-// Extract flirtlib features
 InterestPointVec
-FlirtlibFeatures::extractFeatures (const sm::LaserScan& scan, const tf::StampedTransform& transform) const
+FlirtlibFeatures::extractFeatures (const sensor_msgs::LaserScan& scan, const tf::StampedTransform& transform) const
 {
   boost::shared_ptr<LaserReading> reading = fromRos(scan);
   InterestPointVec pts;
@@ -155,14 +145,13 @@ FlirtlibFeatures::extractFeatures (const sm::LaserScan& scan, const tf::StampedT
   return pts;
 }
 
-
-// Extract from multiple scans
 InterestPointVec
 FlirtlibFeatures::extractFeatures (const std::vector<sensor_msgs::LaserScan>& scans, const std::vector<tf::StampedTransform>& transforms) const
 {
   InterestPointVec pts;
   std::vector<sensor_msgs::LaserScan>::const_iterator scans_iter = scans.begin();
   std::vector<tf::StampedTransform>::const_iterator tf_iter = transforms.begin();
+
   for(; scans_iter != scans.end(); ++scans_iter, ++tf_iter)
   {
     InterestPointVec v = extractFeatures(*scans_iter, *tf_iter);
@@ -170,7 +159,6 @@ FlirtlibFeatures::extractFeatures (const std::vector<sensor_msgs::LaserScan>& sc
   }
 
   return pts;
-
 }
 
 

--- a/src/flirtlib.cpp
+++ b/src/flirtlib.cpp
@@ -39,6 +39,7 @@
 #include <flirtlib_ros/flirtlib.h>
 #include <flirtlib_ros/conversions.h>
 #include <boost/foreach.hpp>
+#include <boost/iterator/zip_iterator.hpp>
 
 namespace flirtlib_ros
 {
@@ -46,40 +47,83 @@ namespace flirtlib_ros
 using std::string;
 namespace sm=sensor_msgs;
 
-Detector* createDetector (SimpleMinMaxPeakFinder* peak_finder)
-{
-  const double scale = 5.0;
-  const double dmst = 2.0;
-  const double base_sigma = 0.2;
-  const double sigma_step = 1.4;
-  CurvatureDetector* det = new CurvatureDetector(peak_finder, scale, base_sigma,
-                                                 sigma_step, dmst);
-  det->setUseMaxRange(false);
-  return det;
-}
-
-DescriptorGenerator* createDescriptor (HistogramDistance<double>* dist)
-{
-  const double min_rho = 0.02;
-  const double max_rho = 0.5;
-  const double bin_rho = 4;
-  const double bin_phi = 12;
-  BetaGridGenerator* gen = new BetaGridGenerator(min_rho, max_rho, bin_rho,
-                                                 bin_phi);
-  gen->setDistanceFunction(dist);
-  return gen;
-}
 
 
 FlirtlibFeatures::FlirtlibFeatures (ros::NodeHandle nh)
+  : nh_(nh)
+  , detector_type_("curvature")
+  , descriptor_type_("Shape Context")
+  , matcher_type_("ransac")
+  , detector_scale_(5.0)
+  , detector_minimum_spanning_trees_num_(2.0)
+  , detector_base_sigma_(0.2)
+  , detector_sigma_step_(1.4)
+  , detector_window_(3)
+  , descriptor_min_rho_(0.02)
+  , descriptor_max_rho_(0.5)
+  , descriptor_bin_rho_(8)
+  , descriptor_bin_phi_(30)
 {
-  ROS_INFO("Note: currently ignoring ros params and using hardcoded params");
+
+  nh_.param("detector_type",  detector_type_,  detector_type_);
+  nh_.param("descriptor_type", descriptor_type_, descriptor_type_);
+  nh_.param("detector_scale", detector_scale_, detector_scale_);
+  nh_.param("detector_minimum_spanning_trees_num", detector_minimum_spanning_trees_num_, detector_minimum_spanning_trees_num_);
+  nh_.param("detector_base_sigma", detector_base_sigma_, detector_base_sigma_);
+  nh_.param("detector_sigma_step", detector_sigma_step_, detector_sigma_step_);
+  nh_.param("detector_window_", detector_window_, detector_window_);
+  nh_.param("descriptor_min_rho", descriptor_min_rho_, descriptor_min_rho_);
+  nh_.param("descriptor_max_rho", descriptor_max_rho_, descriptor_max_rho_);
+  nh_.param("descriptor_bin_rho", descriptor_bin_rho_, descriptor_bin_rho_);
+  nh_.param("descriptor_bin_phi", descriptor_bin_phi_, descriptor_bin_phi_);
+
   peak_finder_.reset(new SimpleMinMaxPeakFinder(0.34, 0.001));
   histogram_dist_.reset(new SymmetricChi2Distance<double>());
-  detector_.reset(createDetector(peak_finder_.get()));
-  descriptor_.reset(createDescriptor(histogram_dist_.get()));
-  ransac_.reset(new RansacFeatureSetMatcher(0.0599, 0.95, 0.4, 0.4,
-                                            0.0384, false));
+
+  peak_finder_ = boost::shared_ptr<SimpleMinMaxPeakFinder>(new SimpleMinMaxPeakFinder(0.34, 0.001));
+  histogram_dist_ = boost::shared_ptr<HistogramDistance<double> >(new SymmetricChi2Distance<double>());
+
+  // Detector
+  if (detector_type_ == "curvature")
+  {
+    CurvatureDetector * det = new CurvatureDetector(peak_finder_.get(), detector_scale_, detector_base_sigma_,
+                                                    detector_sigma_step_,detector_minimum_spanning_trees_num_);
+    det->setUseMaxRange(false);
+    detector_ = boost::shared_ptr<Detector>(det);
+  }
+  else if (detector_type_ == "normal_edge")
+  {
+    detector_ .reset(new NormalEdgeDetector(peak_finder_.get(), detector_scale_, detector_base_sigma_,
+                                            detector_sigma_step_,  detector_window_));
+  }
+  else if (detector_type_ == "normal blob")
+  {
+    detector_.reset(new NormalBlobDetector(peak_finder_.get(),detector_scale_, detector_base_sigma_,
+                                           detector_sigma_step_,  detector_window_));
+  }
+  else if (detector_type_ == "range")
+  {
+    detector_.reset(new RangeDetector(peak_finder_.get(), detector_scale_, detector_base_sigma_,
+                                      detector_sigma_step_));
+  }
+
+  // Descriptor
+  if(descriptor_type_ == "Beta Grid")
+  {
+    BetaGridGenerator * gen = new BetaGridGenerator(descriptor_min_rho_, descriptor_max_rho_,
+                                                    descriptor_bin_rho_, descriptor_bin_phi_);
+    gen->setDistanceFunction(histogram_dist_.get());
+    descriptor_ .reset(gen);
+  }
+  if(descriptor_type_ == "Shape Context")
+  {
+    ShapeContextGenerator * gen = new ShapeContextGenerator(descriptor_min_rho_, descriptor_max_rho_,
+                                                            descriptor_bin_rho_, descriptor_bin_phi_);
+    gen->setDistanceFunction(histogram_dist_.get());
+    descriptor_ .reset(gen);
+  }
+
+  ransac_.reset(new RansacFeatureSetMatcher(0.0299, 0.95, 0.2, 0.1,0.0184, false));
 }
 
 // Extract flirtlib features
@@ -94,6 +138,44 @@ FlirtlibFeatures::extractFeatures (sm::LaserScan::ConstPtr scan) const
   return pts;
 }
 
+// Extract flirtlib features
+InterestPointVec
+FlirtlibFeatures::extractFeatures (const sm::LaserScan& scan, const tf::StampedTransform& transform) const
+{
+  boost::shared_ptr<LaserReading> reading = fromRos(scan);
+  InterestPointVec pts;
+  detector_->detect(*reading, pts);
+  BOOST_FOREACH (InterestPoint* p, pts)
+  {
+    p->setDescriptor(descriptor_->describe(*p, *reading));
+    tf::Vector3 point(p->getPosition().x, p->getPosition().y, 0);
+    point = transform*point;
+    p->setPosition(OrientedPoint2D(point.getX(),point.getY(), p->getPosition().theta));
+  }
+  return pts;
+}
+
+
+// Extract from multiple scans
+InterestPointVec
+FlirtlibFeatures::extractFeatures (const std::vector<sensor_msgs::LaserScan>& scans, const std::vector<tf::StampedTransform>& transforms) const
+{
+  InterestPointVec pts;
+  std::vector<sensor_msgs::LaserScan>::const_iterator scans_iter = scans.begin();
+  std::vector<tf::StampedTransform>::const_iterator tf_iter = transforms.begin();
+  for(; scans_iter != scans.end(); ++scans_iter, ++tf_iter)
+  {
+    InterestPointVec v = extractFeatures(*scans_iter, *tf_iter);
+    pts.insert(pts.end(), v.begin(), v.end());
+  }
+
+  return pts;
+
+}
 
 
 } // namespace
+
+
+
+

--- a/src/generate_scan_map.cpp
+++ b/src/generate_scan_map.cpp
@@ -170,11 +170,12 @@ gm::Pose Node::getPoseAt (const ros::Time& t) const
 RefScanRos Node::extractFeatures (sm::LaserScan::ConstPtr scan,
                                   const gm::Pose& pose)
 {
-  boost::shared_ptr<LaserReading> reading = fromRos(*scan);
-  InterestPointVec pts;
-  features_.detector_->detect(*reading, pts);
+ // boost::shared_ptr<LaserReading> reading = fromRos(*scan);
+  InterestPointVec pts = features_.extractFeatures(scan);
+  /*features_.detector_->detect(*reading, pts);
   BOOST_FOREACH (InterestPoint* p, pts) 
-    p->setDescriptor(features_.descriptor_->describe(*p, *reading));
+    p->setDescriptor(features_.descriptor_->describe(*p, *reading));*/
+
   marker_pub_.publish(interestPointMarkers(pts, pose));
   const RefScan ref(scan, pose, pts);
   return toRos(ref);

--- a/src/localization_monitor_node.cpp
+++ b/src/localization_monitor_node.cpp
@@ -388,7 +388,7 @@ void Node::mapCB (const nm::OccupancyGrid& g)
     {
       Correspondences matches;
       OrientedPoint2D trans;
-      features_.ransac_->matchSets(ref_scan.raw_pts, pts, trans, matches);
+      features_.matcher()->matchSets(ref_scan.raw_pts, pts, trans, matches);
       const unsigned num_matches = matches.size();
       if (num_matches > min_num_matches_) 
       {


### PR DESCRIPTION
Changes the flirtlib interface so it can detect features from multiple scans with corresponding transforms (more than 1 lidar) and makes the parameters of the detector and descriptor ros params instead of hardcoded values in the library.

@efernandez @servos
